### PR TITLE
Compatible way to test request method in controller.

### DIFF
--- a/lib/in_place_editing/controller_methods.rb
+++ b/lib/in_place_editing/controller_methods.rb
@@ -16,7 +16,7 @@ module InPlaceEditing
   module ClassMethods
     def in_place_edit_for(object, attribute, options = {})
       define_method("set_#{object}_#{attribute}") do
-        unless [:post, :put].include?(request.method_symbol) then
+        unless request.post? or request.put? then
           return render(:text => 'Method not allowed', :status => 405)
         end
         @item = object.to_s.camelize.constantize.find(params[:id])


### PR DESCRIPTION
Commit 6fb305cfd46abc69cb9ebb3d84a2a3174e1ac0db replaced request.method with
request.method_symbol which is only available on Rails > 3.0

This commit switches the way we test the request method to use .post? and
.put? instead of .method/.method_symbol.

This restores compatibility with Rails 2.3.
